### PR TITLE
Add FileZilla installation to misc-tools script

### DIFF
--- a/ubuntu-25.04/misc-tools.sh
+++ b/ubuntu-25.04/misc-tools.sh
@@ -61,6 +61,12 @@ sudo apt update && sudo apt install signal-desktop
 sudo snap install slack
 
 # ----------------------------------------
+# File Transfer Tools
+# ----------------------------------------
+echo "📁 Installing FileZilla..."
+sudo apt install -y filezilla
+
+# ----------------------------------------
 # Postman
 # ----------------------------------------
 echo "🧪 Installing Postman..."
@@ -70,4 +76,3 @@ sudo snap install postman
 # Wrap up logging & cleanup
 ########################################
 finalize_logging
-


### PR DESCRIPTION
This PR adds FileZilla FTP client installation to the misc-tools.sh script.

## Changes Made:
- Added FileZilla installation in a new 'File Transfer Tools' section
- Uses apt package manager for clean installation
- Positioned logically in the script flow before the Postman section

## Testing:
The installation command uses the standard Ubuntu package repository, ensuring compatibility and easy maintenance.

FileZilla is a popular cross-platform FTP, FTPS and SFTP client that will be useful for file transfer operations in development environments.