### PR TITLE
Add LangChain, LangGraph, and n8n installation scripts

### DIFF
--- a/ubuntu-25.04/programming-sdks/langchain.sh
+++ b/ubuntu-25.04/programming-sdks/langchain.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+########################################
+# Load utilities (logging, shell-detection, cleanup)
+########################################
+source "$(dirname "$0")/../../env_utils.sh"
+init_logging
+detect_source_file
+ensure_env_dir
+
+########################################
+# LOCAL DIRECTORIES TO STORE ENVIRONMENT SCRIPTS
+########################################
+LANGCHAIN_ENV_FILE="$ENVIRONMENT_DIR/.langchain"
+
+# Function to install LangChain in a virtual environment
+install_langchain() {
+    log "Setting up LangChain installation..."
+    
+    # Check if Python is available
+    if ! command -v python3 &> /dev/null; then
+        err "Python3 is not installed. Please install Python first."
+        exit 1
+    fi
+    
+    # Create virtual environment for LangChain
+    local venv_dir="$HOME/.langchain-venv"
+    if [ ! -d "$venv_dir" ]; then
+        log "Creating virtual environment for LangChain..."
+        python3 -m venv "$venv_dir"
+    else
+        log "Virtual environment already exists at $venv_dir"
+    fi
+    
+    # Activate virtual environment and install LangChain
+    log "Installing LangChain and related packages..."
+    source "$venv_dir/bin/activate"
+    pip install --upgrade pip
+    pip install langchain langchain-core langchain-community langchain-experimental
+    pip install langchain-openai langchain-anthropic langchain-google-genai
+    pip install langsmith
+    deactivate
+    
+    # Create environment file
+    if [ ! -f "$LANGCHAIN_ENV_FILE" ]; then
+        touch "$LANGCHAIN_ENV_FILE"
+    fi
+    
+    cat > "$LANGCHAIN_ENV_FILE" << EOF
+# LangChain Environment Configuration
+export LANGCHAIN_VENV="$venv_dir"
+
+# Function to activate LangChain environment
+activate_langchain() {
+    source "\$LANGCHAIN_VENV/bin/activate"
+    echo "LangChain environment activated"
+}
+
+# Function to deactivate LangChain environment
+deactivate_langchain() {
+    deactivate
+    echo "LangChain environment deactivated"
+}
+EOF
+    
+    log "LangChain installed successfully in virtual environment: $venv_dir"
+}
+
+# Function to install additional LangChain integrations
+install_langchain_integrations() {
+    local venv_dir="$HOME/.langchain-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangChain virtual environment not found. Please install LangChain first."
+        exit 1
+    fi
+    
+    log "Installing additional LangChain integrations..."
+    source "$venv_dir/bin/activate"
+    
+    # Vector stores
+    pip install langchain-chroma langchain-pinecone langchain-weaviate
+    pip install faiss-cpu chromadb
+    
+    # Document loaders
+    pip install pypdf unstructured[local-inference] python-docx
+    
+    # Web scraping
+    pip install beautifulsoup4 selenium requests
+    
+    # Database integrations
+    pip install langchain-postgres psycopg2-binary
+    
+    deactivate
+    log "Additional LangChain integrations installed successfully"
+}
+
+# Function to update LangChain packages
+update_langchain() {
+    local venv_dir="$HOME/.langchain-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangChain virtual environment not found. Please install LangChain first."
+        exit 1
+    fi
+    
+    log "Updating LangChain packages..."
+    source "$venv_dir/bin/activate"
+    pip install --upgrade langchain langchain-core langchain-community langchain-experimental
+    pip install --upgrade langchain-openai langchain-anthropic langchain-google-genai
+    pip install --upgrade langsmith
+    deactivate
+    log "LangChain packages updated successfully"
+}
+
+# Function to show LangChain installation info
+show_langchain_info() {
+    local venv_dir="$HOME/.langchain-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangChain virtual environment not found."
+        exit 1
+    fi
+    
+    log "LangChain Installation Information:"
+    echo "Virtual Environment: $venv_dir"
+    echo "Environment File: $LANGCHAIN_ENV_FILE"
+    echo ""
+    echo "To activate LangChain environment:"
+    echo "  source $LANGCHAIN_ENV_FILE && activate_langchain"
+    echo ""
+    source "$venv_dir/bin/activate"
+    echo "Installed packages:"
+    pip list | grep -i langchain || echo "No LangChain packages found"
+    deactivate
+}
+
+# Ensure $LANGCHAIN_ENV_FILE is sourced in $SOURCE_FILE
+marker="source $LANGCHAIN_ENV_FILE"
+if [ -f "$LANGCHAIN_ENV_FILE" ]; then
+    if ! grep -Fq "$marker" "$SOURCE_FILE"; then
+        echo "$marker" >> "$SOURCE_FILE"
+        log "Added LangChain env script to $SOURCE_FILE. Please restart your shell or run: source $SOURCE_FILE"
+    fi
+fi
+
+# Menu for managing LangChain
+info "Select an option:"
+info "1) Install LangChain"
+info "2) Install additional LangChain integrations"
+info "3) Update LangChain packages"
+info "4) Show LangChain installation info"
+info "5) Exit"
+
+prompt "Enter your choice: "
+read -r choice
+
+case $choice in
+    1) 
+        enable_command_tracing
+        install_langchain
+        ;;
+    2) 
+        enable_command_tracing
+        install_langchain_integrations
+        ;;
+    3) 
+        enable_command_tracing
+        update_langchain
+        ;;
+    4) show_langchain_info ;;
+    5) exit 0 ;;
+    *) err "Invalid option!" ;;
+esac
+
+finalize_logging

--- a/ubuntu-25.04/programming-sdks/langgraph.sh
+++ b/ubuntu-25.04/programming-sdks/langgraph.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+########################################
+# Load utilities (logging, shell-detection, cleanup)
+########################################
+source "$(dirname "$0")/../../env_utils.sh"
+init_logging
+detect_source_file
+ensure_env_dir
+
+########################################
+# LOCAL DIRECTORIES TO STORE ENVIRONMENT SCRIPTS
+########################################
+LANGGRAPH_ENV_FILE="$ENVIRONMENT_DIR/.langgraph"
+
+# Function to install LangGraph in a virtual environment
+install_langgraph() {
+    log "Setting up LangGraph installation..."
+    
+    # Check if Python is available
+    if ! command -v python3 &> /dev/null; then
+        err "Python3 is not installed. Please install Python first."
+        exit 1
+    fi
+    
+    # Create virtual environment for LangGraph
+    local venv_dir="$HOME/.langgraph-venv"
+    if [ ! -d "$venv_dir" ]; then
+        log "Creating virtual environment for LangGraph..."
+        python3 -m venv "$venv_dir"
+    else
+        log "Virtual environment already exists at $venv_dir"
+    fi
+    
+    # Activate virtual environment and install LangGraph
+    log "Installing LangGraph and related packages..."
+    source "$venv_dir/bin/activate"
+    pip install --upgrade pip
+    pip install langgraph langgraph-checkpoint
+    pip install langchain langchain-core langchain-community
+    pip install langsmith
+    deactivate
+    
+    # Create environment file
+    if [ ! -f "$LANGGRAPH_ENV_FILE" ]; then
+        touch "$LANGGRAPH_ENV_FILE"
+    fi
+    
+    cat > "$LANGGRAPH_ENV_FILE" << EOF
+# LangGraph Environment Configuration
+export LANGGRAPH_VENV="$venv_dir"
+
+# Function to activate LangGraph environment
+activate_langgraph() {
+    source "\$LANGGRAPH_VENV/bin/activate"
+    echo "LangGraph environment activated"
+}
+
+# Function to deactivate LangGraph environment
+deactivate_langgraph() {
+    deactivate
+    echo "LangGraph environment deactivated"
+}
+EOF
+    
+    log "LangGraph installed successfully in virtual environment: $venv_dir"
+}
+
+# Function to install LangGraph Studio (development environment)
+install_langgraph_studio() {
+    local venv_dir="$HOME/.langgraph-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangGraph virtual environment not found. Please install LangGraph first."
+        exit 1
+    fi
+    
+    log "Installing LangGraph Studio and development tools..."
+    source "$venv_dir/bin/activate"
+    
+    # Install development and visualization tools
+    pip install langgraph-studio
+    pip install jupyter jupyterlab
+    pip install matplotlib seaborn plotly
+    pip install streamlit gradio
+    
+    deactivate
+    log "LangGraph Studio and development tools installed successfully"
+}
+
+# Function to install additional LangGraph integrations
+install_langgraph_integrations() {
+    local venv_dir="$HOME/.langgraph-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangGraph virtual environment not found. Please install LangGraph first."
+        exit 1
+    fi
+    
+    log "Installing additional LangGraph integrations..."
+    source "$venv_dir/bin/activate"
+    
+    # Database checkpointers
+    pip install langgraph-checkpoint-sqlite langgraph-checkpoint-postgres
+    
+    # Additional LangChain integrations for graphs
+    pip install langchain-openai langchain-anthropic
+    
+    # Graph visualization
+    pip install graphviz pydot networkx
+    
+    # Memory and state management
+    pip install redis
+    
+    deactivate
+    log "Additional LangGraph integrations installed successfully"
+}
+
+# Function to update LangGraph packages
+update_langgraph() {
+    local venv_dir="$HOME/.langgraph-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangGraph virtual environment not found. Please install LangGraph first."
+        exit 1
+    fi
+    
+    log "Updating LangGraph packages..."
+    source "$venv_dir/bin/activate"
+    pip install --upgrade langgraph langgraph-checkpoint
+    pip install --upgrade langchain langchain-core langchain-community
+    pip install --upgrade langsmith
+    deactivate
+    log "LangGraph packages updated successfully"
+}
+
+# Function to show LangGraph installation info
+show_langgraph_info() {
+    local venv_dir="$HOME/.langgraph-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangGraph virtual environment not found."
+        exit 1
+    fi
+    
+    log "LangGraph Installation Information:"
+    echo "Virtual Environment: $venv_dir"
+    echo "Environment File: $LANGGRAPH_ENV_FILE"
+    echo ""
+    echo "To activate LangGraph environment:"
+    echo "  source $LANGGRAPH_ENV_FILE && activate_langgraph"
+    echo ""
+    echo "To start Jupyter Lab:"
+    echo "  activate_langgraph && jupyter lab"
+    echo ""
+    source "$venv_dir/bin/activate"
+    echo "Installed packages:"
+    pip list | grep -E "(langgraph|langchain)" || echo "No LangGraph packages found"
+    deactivate
+}
+
+# Function to create sample LangGraph project
+create_sample_project() {
+    local venv_dir="$HOME/.langgraph-venv"
+    if [ ! -d "$venv_dir" ]; then
+        err "LangGraph virtual environment not found. Please install LangGraph first."
+        exit 1
+    fi
+    
+    local project_dir="$HOME/langgraph-projects"
+    if [ ! -d "$project_dir" ]; then
+        mkdir -p "$project_dir"
+    fi
+    
+    log "Creating sample LangGraph project..."
+    
+    cat > "$project_dir/simple_graph.py" << 'EOF'
+#!/usr/bin/env python3
+"""
+Simple LangGraph example - A basic chatbot with memory
+"""
+
+from typing import TypedDict, Annotated
+from langgraph.graph import StateGraph, START, END
+from langgraph.graph.message import add_messages
+from langchain_core.messages import BaseMessage
+
+class State(TypedDict):
+    messages: Annotated[list[BaseMessage], add_messages]
+
+def chatbot(state: State):
+    # This is a simple echo bot for demonstration
+    last_message = state["messages"][-1]
+    return {"messages": [f"Echo: {last_message.content}"]}
+
+# Build the graph
+graph_builder = StateGraph(State)
+graph_builder.add_node("chatbot", chatbot)
+graph_builder.add_edge(START, "chatbot")
+graph_builder.add_edge("chatbot", END)
+
+graph = graph_builder.compile()
+
+if __name__ == "__main__":
+    # Test the graph
+    from langchain_core.messages import HumanMessage
+    
+    result = graph.invoke({
+        "messages": [HumanMessage(content="Hello, LangGraph!")]
+    })
+    
+    print("Graph output:", result["messages"][-1].content)
+EOF
+    
+    echo "Sample project created at: $project_dir/simple_graph.py"
+    echo "To run: cd $project_dir && activate_langgraph && python simple_graph.py"
+}
+
+# Ensure $LANGGRAPH_ENV_FILE is sourced in $SOURCE_FILE
+marker="source $LANGGRAPH_ENV_FILE"
+if [ -f "$LANGGRAPH_ENV_FILE" ]; then
+    if ! grep -Fq "$marker" "$SOURCE_FILE"; then
+        echo "$marker" >> "$SOURCE_FILE"
+        log "Added LangGraph env script to $SOURCE_FILE. Please restart your shell or run: source $SOURCE_FILE"
+    fi
+fi
+
+# Menu for managing LangGraph
+info "Select an option:"
+info "1) Install LangGraph"
+info "2) Install LangGraph Studio (development tools)"
+info "3) Install additional LangGraph integrations"
+info "4) Update LangGraph packages"
+info "5) Show LangGraph installation info"
+info "6) Create sample LangGraph project"
+info "7) Exit"
+
+prompt "Enter your choice: "
+read -r choice
+
+case $choice in
+    1) 
+        enable_command_tracing
+        install_langgraph
+        ;;
+    2) 
+        enable_command_tracing
+        install_langgraph_studio
+        ;;
+    3) 
+        enable_command_tracing
+        install_langgraph_integrations
+        ;;
+    4) 
+        enable_command_tracing
+        update_langgraph
+        ;;
+    5) show_langgraph_info ;;
+    6) create_sample_project ;;
+    7) exit 0 ;;
+    *) err "Invalid option!" ;;
+esac
+
+finalize_logging

--- a/ubuntu-25.04/programming-sdks/n8n.sh
+++ b/ubuntu-25.04/programming-sdks/n8n.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+
+########################################
+# Load utilities (logging, shell-detection, cleanup)
+########################################
+source "$(dirname "$0")/../../env_utils.sh"
+init_logging
+detect_source_file
+ensure_env_dir
+
+########################################
+# LOCAL DIRECTORIES TO STORE ENVIRONMENT SCRIPTS
+########################################
+N8N_ENV_FILE="$ENVIRONMENT_DIR/.n8n"
+
+# Function to install n8n globally
+install_n8n_global() {
+    log "Installing n8n globally..."
+    
+    # Check if Node.js and npm are available
+    if ! command -v node &> /dev/null; then
+        err "Node.js is not installed. Please install Node.js first."
+        exit 1
+    fi
+    
+    if ! command -v npm &> /dev/null; then
+        err "npm is not installed. Please install npm first."
+        exit 1
+    fi
+    
+    # Install n8n globally
+    log "Installing n8n via npm..."
+    npm install -g n8n
+    
+    # Create environment file
+    if [ ! -f "$N8N_ENV_FILE" ]; then
+        touch "$N8N_ENV_FILE"
+    fi
+    
+    cat > "$N8N_ENV_FILE" << EOF
+# n8n Environment Configuration
+export N8N_USER_FOLDER="\$HOME/.n8n"
+export N8N_BASIC_AUTH_ACTIVE=true
+export N8N_BASIC_AUTH_USER=admin
+export N8N_BASIC_AUTH_PASSWORD=admin
+export N8N_HOST=0.0.0.0
+export N8N_PORT=5678
+export N8N_PROTOCOL=http
+
+# n8n utility functions
+start_n8n() {
+    echo "Starting n8n on http://localhost:\$N8N_PORT"
+    echo "Login: \$N8N_BASIC_AUTH_USER / \$N8N_BASIC_AUTH_PASSWORD"
+    n8n start
+}
+
+start_n8n_tunnel() {
+    echo "Starting n8n with tunnel for webhooks"
+    n8n start --tunnel
+}
+
+update_n8n() {
+    echo "Updating n8n..."
+    npm update -g n8n
+}
+EOF
+    
+    log "n8n installed successfully globally"
+    log "Configuration saved to: $N8N_ENV_FILE"
+}
+
+# Function to install n8n with Docker
+install_n8n_docker() {
+    log "Setting up n8n with Docker..."
+    
+    # Check if Docker is available
+    if ! command -v docker &> /dev/null; then
+        err "Docker is not installed. Please install Docker first."
+        exit 1
+    fi
+    
+    # Create n8n data directory
+    local n8n_data_dir="$HOME/.n8n-docker"
+    mkdir -p "$n8n_data_dir"
+    
+    # Create docker-compose file
+    local compose_file="$n8n_data_dir/docker-compose.yml"
+    cat > "$compose_file" << 'EOF'
+version: '3.8'
+
+services:
+  n8n:
+    image: docker.n8n.io/n8nio/n8n
+    container_name: n8n
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=admin
+      - N8N_BASIC_AUTH_PASSWORD=admin
+      - N8N_HOST=0.0.0.0
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+      - WEBHOOK_URL=http://localhost:5678/
+    volumes:
+      - n8n_data:/home/node/.n8n
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  n8n_data:
+    external: false
+EOF
+    
+    # Update environment file
+    if [ ! -f "$N8N_ENV_FILE" ]; then
+        touch "$N8N_ENV_FILE"
+    fi
+    
+    cat > "$N8N_ENV_FILE" << EOF
+# n8n Docker Environment Configuration
+export N8N_DOCKER_DIR="$n8n_data_dir"
+export N8N_COMPOSE_FILE="$compose_file"
+
+# n8n Docker utility functions
+start_n8n_docker() {
+    echo "Starting n8n with Docker..."
+    cd "\$N8N_DOCKER_DIR"
+    docker-compose up -d
+    echo "n8n is running at http://localhost:5678"
+    echo "Login: admin / admin"
+}
+
+stop_n8n_docker() {
+    echo "Stopping n8n Docker container..."
+    cd "\$N8N_DOCKER_DIR"
+    docker-compose down
+}
+
+restart_n8n_docker() {
+    echo "Restarting n8n Docker container..."
+    cd "\$N8N_DOCKER_DIR"
+    docker-compose restart
+}
+
+logs_n8n_docker() {
+    echo "Showing n8n Docker logs..."
+    cd "\$N8N_DOCKER_DIR"
+    docker-compose logs -f n8n
+}
+
+update_n8n_docker() {
+    echo "Updating n8n Docker image..."
+    cd "\$N8N_DOCKER_DIR"
+    docker-compose pull
+    docker-compose up -d
+}
+EOF
+    
+    log "n8n Docker setup completed"
+    log "Docker Compose file: $compose_file"
+    log "Configuration saved to: $N8N_ENV_FILE"
+}
+
+# Function to install n8n self-hosted with database
+install_n8n_selfhosted() {
+    log "Setting up n8n self-hosted with PostgreSQL..."
+    
+    # Check if Docker is available
+    if ! command -v docker &> /dev/null; then
+        err "Docker is not installed. Please install Docker first."
+        exit 1
+    fi
+    
+    # Create n8n self-hosted directory
+    local n8n_dir="$HOME/.n8n-selfhosted"
+    mkdir -p "$n8n_dir"
+    
+    # Create docker-compose file with PostgreSQL
+    local compose_file="$n8n_dir/docker-compose.yml"
+    cat > "$compose_file" << 'EOF'
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: n8n-postgres
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=n8n
+      - POSTGRES_PASSWORD=n8n_password
+      - POSTGRES_DB=n8n
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -h localhost -U n8n']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  n8n:
+    image: docker.n8n.io/n8nio/n8n
+    container_name: n8n-app
+    restart: unless-stopped
+    ports:
+      - "5678:5678"
+    environment:
+      - DB_TYPE=postgresdb
+      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_PORT=5432
+      - DB_POSTGRESDB_DATABASE=n8n
+      - DB_POSTGRESDB_USER=n8n
+      - DB_POSTGRESDB_PASSWORD=n8n_password
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=admin
+      - N8N_BASIC_AUTH_PASSWORD=admin123
+      - N8N_HOST=0.0.0.0
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+      - WEBHOOK_URL=http://localhost:5678/
+      - GENERIC_TIMEZONE=UTC
+    volumes:
+      - n8n_data:/home/node/.n8n
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:
+    external: false
+  n8n_data:
+    external: false
+EOF
+    
+    # Update environment file
+    if [ ! -f "$N8N_ENV_FILE" ]; then
+        touch "$N8N_ENV_FILE"
+    fi
+    
+    cat > "$N8N_ENV_FILE" << EOF
+# n8n Self-hosted Environment Configuration
+export N8N_SELFHOSTED_DIR="$n8n_dir"
+export N8N_SELFHOSTED_COMPOSE_FILE="$compose_file"
+
+# n8n Self-hosted utility functions
+start_n8n_selfhosted() {
+    echo "Starting n8n self-hosted with PostgreSQL..."
+    cd "\$N8N_SELFHOSTED_DIR"
+    docker-compose up -d
+    echo "Waiting for services to be ready..."
+    sleep 10
+    echo "n8n is running at http://localhost:5678"
+    echo "Login: admin / admin123"
+}
+
+stop_n8n_selfhosted() {
+    echo "Stopping n8n self-hosted..."
+    cd "\$N8N_SELFHOSTED_DIR"
+    docker-compose down
+}
+
+restart_n8n_selfhosted() {
+    echo "Restarting n8n self-hosted..."
+    cd "\$N8N_SELFHOSTED_DIR"
+    docker-compose restart
+}
+
+logs_n8n_selfhosted() {
+    echo "Showing n8n self-hosted logs..."
+    cd "\$N8N_SELFHOSTED_DIR"
+    docker-compose logs -f
+}
+
+backup_n8n_data() {
+    echo "Creating backup of n8n data..."
+    cd "\$N8N_SELFHOSTED_DIR"
+    docker-compose exec postgres pg_dump -U n8n n8n > "n8n_backup_\$(date +%Y%m%d_%H%M%S).sql"
+    echo "Backup created in \$N8N_SELFHOSTED_DIR"
+}
+EOF
+    
+    log "n8n self-hosted setup completed"
+    log "Docker Compose file: $compose_file"
+    log "Configuration saved to: $N8N_ENV_FILE"
+}
+
+# Function to show n8n installation info
+show_n8n_info() {
+    log "n8n Installation Information:"
+    echo "Environment File: $N8N_ENV_FILE"
+    echo ""
+    
+    if command -v n8n &> /dev/null; then
+        echo "n8n global installation: $(which n8n)"
+        echo "n8n version: $(n8n --version)"
+    else
+        echo "n8n global installation: Not found"
+    fi
+    
+    if [ -f "$HOME/.n8n-docker/docker-compose.yml" ]; then
+        echo "n8n Docker setup: Available at $HOME/.n8n-docker/"
+    fi
+    
+    if [ -f "$HOME/.n8n-selfhosted/docker-compose.yml" ]; then
+        echo "n8n Self-hosted setup: Available at $HOME/.n8n-selfhosted/"
+    fi
+    
+    echo ""
+    echo "Available functions (after sourcing environment):"
+    if [ -f "$N8N_ENV_FILE" ]; then
+        grep "^[a-zA-Z_][a-zA-Z0-9_]*\s*()" "$N8N_ENV_FILE" | sed 's/() {//' || true
+    fi
+}
+
+# Function to uninstall n8n
+uninstall_n8n() {
+    log "Uninstalling n8n..."
+    
+    prompt "This will remove n8n installations and data. Continue? (y/N): "
+    read -r confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        log "Uninstall cancelled"
+        exit 0
+    fi
+    
+    # Stop Docker containers if running
+    if [ -f "$HOME/.n8n-docker/docker-compose.yml" ]; then
+        cd "$HOME/.n8n-docker" && docker-compose down 2>/dev/null || true
+    fi
+    
+    if [ -f "$HOME/.n8n-selfhosted/docker-compose.yml" ]; then
+        cd "$HOME/.n8n-selfhosted" && docker-compose down 2>/dev/null || true
+    fi
+    
+    # Remove global installation
+    if command -v n8n &> /dev/null; then
+        npm uninstall -g n8n
+    fi
+    
+    # Remove Docker setups
+    rm -rf "$HOME/.n8n-docker" "$HOME/.n8n-selfhosted"
+    
+    # Remove environment file
+    rm -f "$N8N_ENV_FILE"
+    
+    log "n8n uninstalled successfully"
+}
+
+# Ensure $N8N_ENV_FILE is sourced in $SOURCE_FILE
+marker="source $N8N_ENV_FILE"
+if [ -f "$N8N_ENV_FILE" ]; then
+    if ! grep -Fq "$marker" "$SOURCE_FILE"; then
+        echo "$marker" >> "$SOURCE_FILE"
+        log "Added n8n env script to $SOURCE_FILE. Please restart your shell or run: source $SOURCE_FILE"
+    fi
+fi
+
+# Menu for managing n8n
+info "Select an option:"
+info "1) Install n8n globally (npm)"
+info "2) Install n8n with Docker (simple)"
+info "3) Install n8n self-hosted (Docker + PostgreSQL)"
+info "4) Show n8n installation info"
+info "5) Uninstall n8n"
+info "6) Exit"
+
+prompt "Enter your choice: "
+read -r choice
+
+case $choice in
+    1) 
+        enable_command_tracing
+        install_n8n_global
+        ;;
+    2) 
+        enable_command_tracing
+        install_n8n_docker
+        ;;
+    3) 
+        enable_command_tracing
+        install_n8n_selfhosted
+        ;;
+    4) show_n8n_info ;;
+    5) 
+        enable_command_tracing
+        uninstall_n8n
+        ;;
+    6) exit 0 ;;
+    *) err "Invalid option!" ;;
+esac
+
+finalize_logging


### PR DESCRIPTION
Added three new installation scripts to programming-sdks directory:

- langchain.sh: Installs LangChain framework with virtual environment setup
  - Includes core packages (langchain-core, langchain-community, langchain-experimental)
  - Popular integrations for OpenAI, Anthropic, and Google GenAI
  - Additional packages for vector stores, document loaders, and web scraping
  - Environment configuration with activation/deactivation functions

- langgraph.sh: Installs LangGraph for building stateful, multi-actor applications
  - Core LangGraph packages with checkpoint support
  - LangGraph Studio development environment
  - Database checkpointers for SQLite and PostgreSQL
  - Sample project creation and visualization tools

- n8n.sh: Installs n8n workflow automation platform with multiple deployment options
  - Global npm installation for simple setup
  - Docker-based deployment for containerized environments
  - Self-hosted setup with PostgreSQL for production use
  - Management functions for container lifecycle and data backup

All scripts follow existing repository patterns with:
- Proper error handling and logging via env_utils.sh
- Interactive menus for installation options
- Environment file management for easy activation
- Virtual environments to prevent package conflicts